### PR TITLE
Fix issue with slashes in filenames

### DIFF
--- a/src/gist_api.rs
+++ b/src/gist_api.rs
@@ -104,7 +104,10 @@ impl Request {
         let mut s = String::new();
         f.read_to_string(&mut s).chain_err(|| ErrorKind::BadInput)?;
         self.text = s;
-        self.filename = String::from(filename.split('/').last().unwrap());
+        self.filename = match filename.rsplit(std::path::MAIN_SEPARATOR).next() {
+            Some(x) => x.to_owned(),
+            None => filename.clone(),
+        };
         Ok(self)
     }
 }

--- a/src/gist_api.rs
+++ b/src/gist_api.rs
@@ -104,7 +104,7 @@ impl Request {
         let mut s = String::new();
         f.read_to_string(&mut s).chain_err(|| ErrorKind::BadInput)?;
         self.text = s;
-        self.filename = filename;
+        self.filename = String::from(filename.split('/').last().unwrap());
         Ok(self)
     }
 }


### PR DESCRIPTION
Hi! I was testing this earlier today and I noticed a bug where if you give a filename with any slashes, e.g.:

```
rust-gist ./test.txt
```

or

```
rust-gist ~/files/test.txt
```

Github rejects it with the message: 

```
error: Github won't accept this Gist. See the answer below:
{"message":"Validation Failed","errors":[{"resource":"Gist","code":"invalid","field":"files"},
  {"resource":"Gist","code":"custom","field":"Whoops,","message":"Whoops, files can't contain 
  malformed path components."}],"documentation_url":"https://developer.github.com/v3/gists/#create-a-gist"}
```

I've fixed this by only selecting from the last slash to the end of the string as the filename that gets sent to Github.

Thanks for the client! I'll definitely be using it in the future.